### PR TITLE
Add training dashboard and module detail page

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,7 +1,9 @@
+import Link from 'next/link';
 import PolarCard from '@/components/PolarCard';
 import RoleBadge from '@/components/RoleBadge';
 import { createServerSupabase } from '@/lib/serverSupabase';
 import type { PostgrestError } from '@supabase/supabase-js';
+import { getActiveTrainingModule, trainingLibrary, trainingMilestones } from '@/lib/trainingLibrary';
 
 export default async function AppDashboard() {
   const supabase = await createServerSupabase();
@@ -23,30 +25,140 @@ export default async function AppDashboard() {
     profileError = mapProfileError(error);
   }
 
+  const activeTraining = getActiveTrainingModule();
+  const upcomingMilestones = trainingMilestones.map((milestone) => ({
+    ...milestone,
+    href: `/app/trainings/${milestone.moduleSlug}`
+  }));
+
   return (
     <main className="page">
-      <PolarCard
-        title="Polar Ops Command"
-        subtitle={user?.email ? `Authenticated as ${user.email}` : 'Supabase session not detected'}
-        className="dashboard"
-      >
-        <div className="dashboard__meta">
-          <div>
-            <span className="muted">Role</span>
+      <div className="dashboard">
+        <PolarCard
+          title="Polar Ops Command"
+          subtitle={
+            user?.email ? `Authenticated as ${user.email}` : 'Supabase session not detected'
+          }
+          className="dashboard-card dashboard-card--profile"
+        >
+          <div className="dashboard__meta">
             <div>
-              <RoleBadge role={profile?.role ?? 'employee'} />
+              <p className="muted">Welcome back</p>
+              <h2 className="dashboard__headline">
+                {profile?.email ?? user?.email ?? 'Trainee'}
+              </h2>
+              <p className="dashboard__subheadline">
+                Review your status and jump into today&apos;s communication drills.
+              </p>
+            </div>
+            <div className="dashboard__details">
+              <div>
+                <span className="muted">Role</span>
+                <div>
+                  <RoleBadge role={profile?.role ?? 'employee'} />
+                </div>
+              </div>
+              <div>
+                <span className="muted">Email</span>
+                <p>{profile?.email ?? user?.email ?? 'Unknown'}</p>
+              </div>
+              {activeTraining && (
+                <div>
+                  <span className="muted">Active module</span>
+                  <p className="dashboard__detail-title">{activeTraining.title}</p>
+                  <p className="muted">
+                    {activeTraining.progress}% complete · {activeTraining.duration}
+                  </p>
+                </div>
+              )}
+            </div>
+            {profileError && <p className="status-message error">{profileError}</p>}
+            {profile?.updated_at && (
+              <p className="muted">Last updated {new Date(profile.updated_at).toLocaleString()}</p>
+            )}
+            <div className="dashboard__quick">
+              {activeTraining && (
+                <Link href={`/app/trainings/${activeTraining.slug}`} className="btn btn-primary">
+                  Resume training
+                </Link>
+              )}
+              <Link href="#training-library" className="btn btn-outline">
+                Browse trainings
+              </Link>
             </div>
           </div>
-          <div>
-            <span className="muted">Email</span>
-            <p>{profile?.email ?? user?.email ?? 'Unknown'}</p>
-          </div>
-          {profileError && <p className="status-message error">{profileError}</p>}
-          {profile?.updated_at && (
-            <p className="muted">Last updated {new Date(profile.updated_at).toLocaleString()}</p>
-          )}
-        </div>
-      </PolarCard>
+        </PolarCard>
+
+        <PolarCard
+          id="training-library"
+          title="Training library"
+          subtitle="Choose a module to focus on today."
+          className="dashboard-card"
+        >
+          <ul className="training-grid">
+            {trainingLibrary.map((training) => (
+              <li key={training.slug}>
+                <Link href={`/app/trainings/${training.slug}`} className="training-card">
+                  <div className="training-card__meta">
+                    <span
+                      className={`training-card__status training-card__status--${training.status
+                        .toLowerCase()
+                        .replace(/\s+/g, '-')}`}
+                    >
+                      {training.status}
+                    </span>
+                    <span className="training-card__duration">{training.duration}</span>
+                  </div>
+                  <h3 className="training-card__title">{training.title}</h3>
+                  <p className="training-card__description">{training.summary}</p>
+                  <div className="training-card__tags">
+                    <span className="training-card__tag">{training.category}</span>
+                    <span className="training-card__tag">{training.level}</span>
+                  </div>
+                  <div className="training-card__progress">
+                    <div className="training-card__progress-bar">
+                      <span
+                        className="training-card__progress-fill"
+                        style={{ width: `${training.progress}%` }}
+                      />
+                    </div>
+                    <span className="training-card__progress-value">
+                      {training.progress}% complete
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </PolarCard>
+
+        <PolarCard
+          title="Upcoming milestones"
+          subtitle="Stay ahead of your assigned checkpoints."
+          className="dashboard-card"
+        >
+          <ul className="dashboard-list">
+            {upcomingMilestones.map((milestone) => {
+              const training = trainingLibrary.find((item) => item.slug === milestone.moduleSlug);
+
+              return (
+                <li key={milestone.id}>
+                  <Link href={milestone.href} className="dashboard-list__item">
+                    <div>
+                      <p className="dashboard-list__title">{milestone.title}</p>
+                      <p className="dashboard-list__description">{milestone.description}</p>
+                      {training && (
+                        <span className="dashboard-list__badge">{training.title}</span>
+                      )}
+                    </div>
+                    <span className="dashboard-list__due">{milestone.due}</span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </PolarCard>
+      </div>
     </main>
   );
 }

--- a/app/app/trainings/[slug]/page.tsx
+++ b/app/app/trainings/[slug]/page.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import PolarCard from '@/components/PolarCard';
+import { getTrainingModule } from '@/lib/trainingLibrary';
+
+type TrainingDetailPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export default function TrainingDetailPage({ params }: TrainingDetailPageProps) {
+  const training = getTrainingModule(params.slug);
+
+  if (!training) {
+    notFound();
+  }
+
+  return (
+    <main className="page">
+      <PolarCard
+        title={training.title}
+        subtitle={training.nextAction}
+        className="dashboard-card training-detail-card"
+      >
+        <div className="training-detail">
+          <p className="training-detail__summary">{training.description}</p>
+          <div className="training-detail__meta">
+            <div className="training-detail__meta-item">
+              <span className="muted">Status</span>
+              <p>{training.status}</p>
+            </div>
+            <div className="training-detail__meta-item">
+              <span className="muted">Duration</span>
+              <p>{training.duration}</p>
+            </div>
+            <div className="training-detail__meta-item">
+              <span className="muted">Level</span>
+              <p>{training.level}</p>
+            </div>
+            <div className="training-detail__meta-item">
+              <span className="muted">Category</span>
+              <p>{training.category}</p>
+            </div>
+            <div className="training-detail__meta-item">
+              <span className="muted">Progress</span>
+              <p>{training.progress}% complete</p>
+            </div>
+          </div>
+          <div className="training-detail__focus">
+            <h2 className="training-detail__subheading">Focus areas</h2>
+            <ul className="training-detail__focus-list">
+              {training.focusAreas.map((focus) => (
+                <li key={focus}>{focus}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="training-detail__focus">
+            <h2 className="training-detail__subheading">Expected outcomes</h2>
+            <ul className="training-detail__focus-list">
+              {training.outcomes.map((outcome) => (
+                <li key={outcome}>{outcome}</li>
+              ))}
+            </ul>
+          </div>
+          <div className="dashboard__quick training-detail__actions">
+            <Link href="/app" className="btn btn-outline">
+              Back to dashboard
+            </Link>
+            <Link
+              href={`/app/trainings/${training.slug}?start=next`}
+              className="btn btn-primary"
+            >
+              Start next session
+            </Link>
+          </div>
+        </div>
+      </PolarCard>
+    </main>
+  );
+}

--- a/components/PolarCard.tsx
+++ b/components/PolarCard.tsx
@@ -6,11 +6,12 @@ type PolarCardProps = {
   subtitle?: string;
   children: ReactNode;
   className?: string;
+  id?: string;
 };
 
-export default function PolarCard({ title, subtitle, children, className }: PolarCardProps) {
+export default function PolarCard({ title, subtitle, children, className, id }: PolarCardProps) {
   return (
-    <section className={clsx('polar-card', className)}>
+    <section id={id} className={clsx('polar-card', className)}>
       {(title || subtitle) && (
         <header className="polar-card__header">
           {title && <h1 className="polar-card__title">{title}</h1>}

--- a/lib/trainingLibrary.ts
+++ b/lib/trainingLibrary.ts
@@ -1,0 +1,116 @@
+export type TrainingModuleStatus = 'In progress' | 'Assigned' | 'Not started';
+
+export type TrainingModule = {
+  slug: string;
+  title: string;
+  summary: string;
+  description: string;
+  category: string;
+  status: TrainingModuleStatus;
+  duration: string;
+  progress: number;
+  level: 'Foundation' | 'Intermediate' | 'Advanced';
+  focusAreas: string[];
+  outcomes: string[];
+  nextAction: string;
+};
+
+export type TrainingMilestone = {
+  id: string;
+  moduleSlug: string;
+  title: string;
+  description: string;
+  due: string;
+};
+
+export const trainingLibrary: TrainingModule[] = [
+  {
+    slug: 'phonetic-alphabet',
+    title: 'Phonetic Alphabet Drills',
+    summary: 'Sharpen clarity of radio transmissions with timed runway and gate scenarios.',
+    description:
+      'Work through scenario-based transmissions with timed recall to reinforce NATO phonetics under peak-traffic pressure.',
+    category: 'Phonetic',
+    status: 'In progress',
+    duration: '15 minutes',
+    progress: 68,
+    level: 'Foundation',
+    focusAreas: ['Gate departure clearances', 'Rapid response callouts', 'Crew readbacks'],
+    outcomes: [
+      'Deliver callouts with 95% accuracy across mixed flight rosters.',
+      'Hold response cadence under five seconds for urgent instructions.',
+      'Coach teammates on misreads using standardized correction phrasing.'
+    ],
+    nextAction: 'Resume Scenario 3: Peak-hour pushback coordination'
+  },
+  {
+    slug: 'de-ice-procedures',
+    title: 'De-ice Procedures Simulation',
+    summary: 'Rehearse coordinated cold-weather operations and complete pre-takeoff checklists.',
+    description:
+      'Step through multi-crew de-ice communications while validating holdover calculations and safety verifications.',
+    category: 'De-ice',
+    status: 'Assigned',
+    duration: '20 minutes',
+    progress: 22,
+    level: 'Intermediate',
+    focusAreas: ['Type IV fluid briefings', 'Holdover monitoring', 'Cabin status updates'],
+    outcomes: [
+      'Call the correct fluid type and sequence without referencing prompts.',
+      'Document de-ice status updates with compliant phraseology.',
+      'Coordinate with ground teams while maintaining sterile cockpit tone.'
+    ],
+    nextAction: 'Review holdover timer drill before tonight\'s shift'
+  },
+  {
+    slug: 'movement-briefings',
+    title: 'Movement & Pushback Briefings',
+    summary: 'Lead safe taxi and pushback communications for congested apron environments.',
+    description:
+      'Coordinate crew, tower, and tug responsibilities in complex ramp layouts to eliminate radio conflicts.',
+    category: 'Movement',
+    status: 'Not started',
+    duration: '12 minutes',
+    progress: 0,
+    level: 'Advanced',
+    focusAreas: ['Tug handoff scripts', 'Hot-spot avoidance', 'Ramp situational updates'],
+    outcomes: [
+      'Sequence pushback duties with zero conflicting instructions.',
+      'Flag airfield hot-spots before ground taxi begins.',
+      'Lead post-briefing recap that captures actionable ramp risks.'
+    ],
+    nextAction: 'Walk through pushback briefing checklist with your supervisor'
+  }
+];
+
+export const trainingMilestones: TrainingMilestone[] = [
+  {
+    id: 'phonetic-check',
+    moduleSlug: 'phonetic-alphabet',
+    title: 'Phonetic scenario evaluation',
+    description: 'Complete Scenario 3 with at least 90% callout accuracy.',
+    due: 'Due April 12'
+  },
+  {
+    id: 'de-ice-audit',
+    moduleSlug: 'de-ice-procedures',
+    title: 'De-ice audit review',
+    description: 'Submit holdover documentation for yesterday\'s simulated sortie.',
+    due: 'Due April 15'
+  },
+  {
+    id: 'movement-observation',
+    moduleSlug: 'movement-briefings',
+    title: 'Movement observation ride',
+    description: 'Shadow a lead dispatcher and capture three ramp risk notes.',
+    due: 'Due April 19'
+  }
+];
+
+export function getTrainingModule(slug: string): TrainingModule | undefined {
+  return trainingLibrary.find((module) => module.slug === slug);
+}
+
+export function getActiveTrainingModule(): TrainingModule | undefined {
+  return trainingLibrary.find((module) => module.status === 'In progress') ?? trainingLibrary[0];
+}

--- a/polar.css
+++ b/polar.css
@@ -244,22 +244,281 @@ input[type='text']:focus {
 
 .dashboard {
   width: 100%;
-  max-width: 720px;
+  max-width: 1100px;
+  display: grid;
+  gap: 1.75rem;
+  align-content: start;
+  grid-template-columns: minmax(0, 1fr);
 }
 
-.dashboard h2 {
-  margin: 0;
-  font-size: 1.5rem;
+.dashboard-card {
+  max-width: none;
+}
+
+.dashboard-card--profile {
+  grid-column: 1 / -1;
 }
 
 .dashboard__meta {
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard__headline {
+  margin: 0;
+  font-size: 1.65rem;
+  font-weight: 700;
+}
+
+.dashboard__subheadline {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  max-width: 48ch;
+}
+
+.dashboard__details {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dashboard__detail-title {
+  margin: 0.25rem 0 0.35rem;
+  font-weight: 600;
+}
+
+.dashboard__quick {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
 .muted {
   color: rgba(226, 232, 240, 0.65);
+}
+
+.training-grid {
+  display: grid;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.training-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.35rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  transition: transform 0.15s ease, border-color 0.2s ease, background 0.25s ease;
+}
+
+.training-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.training-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.training-card__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.training-card__status--in-progress {
+  background: rgba(56, 189, 248, 0.18);
+  color: #e0f2fe;
+}
+
+.training-card__status--assigned {
+  background: rgba(129, 140, 248, 0.2);
+  color: #e9e7ff;
+}
+
+.training-card__status--not-started {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.training-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--polar-text);
+}
+
+.training-card__description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.92rem;
+}
+
+.training-card__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.training-card__tag {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.training-card__progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.training-card__progress-bar {
+  height: 0.45rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.training-card__progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--polar-primary), var(--polar-primary-dark));
+}
+
+.training-card__progress-value {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.dashboard-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dashboard-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: border-color 0.2s ease, transform 0.15s ease;
+}
+
+.dashboard-list__item:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  transform: translateY(-1px);
+}
+
+.dashboard-list__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--polar-text);
+}
+
+.dashboard-list__description {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.dashboard-list__badge {
+  display: inline-flex;
+  margin-top: 0.6rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.16);
+  font-size: 0.75rem;
+  color: #e0f2fe;
+}
+
+.dashboard-list__due {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  white-space: nowrap;
+}
+
+.training-detail-card {
+  max-width: 760px;
+}
+
+.training-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.training-detail__summary {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.training-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+}
+
+.training-detail__meta-item {
+  min-width: 140px;
+}
+
+.training-detail__meta-item p {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+}
+
+.training-detail__subheading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--polar-text);
+}
+
+.training-detail__focus-list {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.training-detail__actions {
+  justify-content: flex-start;
+}
+
+@media (min-width: 960px) {
+  .dashboard {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 640px) {
@@ -275,6 +534,19 @@ input[type='text']:focus {
 
   .polar-card {
     padding: 2rem;
+  }
+
+  .training-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard-list__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-list__due {
+    margin-top: 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the authenticated dashboard to highlight available training modules and upcoming milestones
- add a shared training library data source plus module detail route for deeper context
- extend polar card styling and ids to support the new grid layout and interactive cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d33b4f15e8832ba25f44d67575e95f