### PR TITLE
refactor(theme): apply Steel Glacier palette and card styles across all screens

### DIFF
--- a/components/AppNav.tsx
+++ b/components/AppNav.tsx
@@ -11,25 +11,14 @@ export default function AppNav({ brand, userEmail }: AppNavProps) {
       <Link href="/" className="app-nav__brand">
         {brand}
       </Link>
-      <nav className="app-nav__links">
-        {userEmail ? (
-          <>
-            <span className="app-nav__user">{userEmail}</span>
-            <Link href="/auth/logout" className="btn btn-outline">
-              Sign out
-            </Link>
-          </>
-        ) : (
-          <>
-            <Link href="/login" className="btn btn-subtle">
-              Log in
-            </Link>
-            <Link href="/signup" className="btn btn-primary">
-              Sign up
-            </Link>
-          </>
-        )}
-      </nav>
+      {userEmail ? (
+        <nav className="app-nav__links">
+          <span className="app-nav__user">{userEmail}</span>
+          <Link href="/auth/logout" className="btn btn-outline">
+            Sign out
+          </Link>
+        </nav>
+      ) : null}
     </header>
   );
 }

--- a/polar.css
+++ b/polar.css
@@ -1,14 +1,15 @@
 :root {
-  --polar-bg: linear-gradient(160deg, #0f172a 0%, #1e3a8a 50%, #38bdf8 100%);
-  --polar-card: rgba(15, 23, 42, 0.65);
-  --polar-card-border: rgba(148, 163, 184, 0.2);
-  --polar-text: #e2e8f0;
-  --polar-muted: #cbd5f5;
-  --polar-primary: #38bdf8;
-  --polar-primary-dark: #0ea5e9;
-  --polar-outline: rgba(56, 189, 248, 0.5);
+  --polar-bg: linear-gradient(to bottom, #2d3a4a 0%, #435c73 100%);
+  --polar-card: rgba(255, 255, 255, 0.05);
+  --polar-card-border: rgba(255, 255, 255, 0.1);
+  --polar-text: rgba(255, 255, 255, 0.85);
+  --polar-muted: rgba(255, 255, 255, 0.7);
+  --polar-title: rgba(255, 255, 255, 0.95);
+  --polar-primary: rgba(255, 255, 255, 0.7);
+  --polar-primary-dark: rgba(255, 255, 255, 0.7);
+  --polar-outline: rgba(255, 255, 255, 0.3);
   --polar-radius: 1.5rem;
-  --polar-shadow: 0 20px 50px rgba(15, 23, 42, 0.45);
+  --polar-shadow: 0 18px 42px rgba(0, 0, 0, 0.2);
 }
 
 *,
@@ -59,8 +60,8 @@ a {
   top: 0;
   z-index: 10;
   backdrop-filter: blur(20px);
-  background: rgba(15, 23, 42, 0.45);
-  border-bottom: 1px solid var(--polar-card-border);
+  background: rgba(45, 58, 74, 0.55);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .app-nav__brand {
@@ -69,6 +70,7 @@ a {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   text-align: center;
+  color: var(--polar-title);
 }
 
 .app-nav__links {
@@ -80,7 +82,7 @@ a {
 
 .app-nav__user {
   font-size: 0.875rem;
-  opacity: 0.85;
+  color: var(--polar-muted);
 }
 
 .polar-card {
@@ -103,6 +105,7 @@ a {
   margin: 0;
   font-size: 1.75rem;
   font-weight: 700;
+  color: var(--polar-title);
 }
 
 .polar-card__subtitle {
@@ -128,15 +131,16 @@ label {
   flex-direction: column;
   gap: 0.5rem;
   font-size: 0.9rem;
+  color: var(--polar-muted);
 }
 
 input[type='email'],
 input[type='password'],
 input[type='text'] {
   border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   padding: 0.75rem 1rem;
-  background: rgba(15, 23, 42, 0.5);
+  background: rgba(67, 92, 115, 0.35);
   color: var(--polar-text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -145,8 +149,8 @@ input[type='email']:focus,
 input[type='password']:focus,
 input[type='text']:focus {
   outline: none;
-  border-color: var(--polar-outline);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.2);
 }
 
 .btn {
@@ -168,33 +172,34 @@ input[type='text']:focus {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--polar-primary), var(--polar-primary-dark));
-  color: #0b1120;
-  box-shadow: 0 12px 30px rgba(14, 165, 233, 0.35);
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--polar-title);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
 }
 
 .btn-primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 16px 32px rgba(14, 165, 233, 0.45);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.3);
 }
 
 .btn-outline {
-  background: transparent;
-  border-color: rgba(148, 163, 184, 0.4);
-  color: var(--polar-text);
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: var(--polar-title);
 }
 
 .btn-outline:hover {
-  border-color: var(--polar-primary);
+  border-color: rgba(255, 255, 255, 0.45);
 }
 
 .btn-subtle {
-  background: rgba(148, 163, 184, 0.12);
+  background: rgba(255, 255, 255, 0.12);
   color: var(--polar-muted);
 }
 
 .btn-subtle:hover {
-  background: rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.18);
 }
 
 .helper-text {
@@ -206,18 +211,21 @@ input[type='text']:focus {
   border-radius: 1rem;
   padding: 0.85rem 1rem;
   font-size: 0.9rem;
-  background: rgba(15, 23, 42, 0.65);
-  border: 1px solid rgba(56, 189, 248, 0.3);
+  background: rgba(67, 92, 115, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--polar-text);
 }
 
 .status-message.error {
-  border-color: rgba(248, 113, 113, 0.7);
-  color: #fecaca;
+  background: rgba(244, 63, 94, 0.2);
+  border-color: rgba(244, 63, 94, 0.35);
+  color: rgba(255, 228, 232, 0.95);
 }
 
 .status-message.success {
-  border-color: rgba(74, 222, 128, 0.5);
-  color: #bbf7d0;
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: rgba(224, 255, 244, 0.95);
 }
 
 .role-badge {
@@ -228,21 +236,27 @@ input[type='text']:focus {
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.02em;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--polar-title);
 }
 
 .badge-employee {
-  background: rgba(56, 189, 248, 0.15);
-  color: #bae6fd;
+  background: rgba(79, 209, 197, 0.2);
+  border-color: rgba(79, 209, 197, 0.35);
+  color: rgba(224, 255, 250, 0.95);
 }
 
 .badge-manager {
-  background: rgba(129, 140, 248, 0.18);
-  color: #c7d2fe;
+  background: rgba(137, 186, 255, 0.22);
+  border-color: rgba(137, 186, 255, 0.35);
+  color: rgba(233, 244, 255, 0.95);
 }
 
 .badge-admin {
-  background: rgba(248, 113, 113, 0.22);
-  color: #fecaca;
+  background: rgba(244, 63, 94, 0.22);
+  border-color: rgba(244, 63, 94, 0.35);
+  color: rgba(255, 228, 232, 0.95);
 }
 
 .dashboard {
@@ -276,7 +290,7 @@ input[type='text']:focus {
 
 .dashboard__subheadline {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(255, 255, 255, 0.8);
   max-width: 48ch;
 }
 
@@ -311,11 +325,12 @@ input[type='text']:focus {
 .metric-card {
   padding: 1rem 1.1rem;
   border-radius: 1.15rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
+  backdrop-filter: blur(18px);
 }
 
 .metric-card__label {
@@ -323,7 +338,7 @@ input[type='text']:focus {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 0.7rem;
-  color: rgba(226, 232, 240, 0.68);
+  color: rgba(255, 255, 255, 0.68);
 }
 
 .metric-card__value {
@@ -336,7 +351,7 @@ input[type='text']:focus {
 .metric-card__helper {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.75);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .status-pill {
@@ -349,26 +364,33 @@ input[type='text']:focus {
   font-size: 0.75rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .status-pill--success {
-  background: rgba(34, 197, 94, 0.18);
-  color: #bbf7d0;
+  background: rgba(16, 185, 129, 0.2);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: rgba(224, 255, 244, 0.95);
 }
 
 .status-pill--warning {
-  background: rgba(251, 191, 36, 0.22);
-  color: #fde68a;
+  background: rgba(245, 158, 11, 0.2);
+  border-color: rgba(251, 191, 36, 0.3);
+  color: rgba(255, 243, 207, 0.95);
 }
 
 .status-pill--info {
-  background: rgba(129, 140, 248, 0.22);
-  color: #e9d5ff;
+  background: rgba(137, 186, 255, 0.22);
+  border-color: rgba(137, 186, 255, 0.3);
+  color: rgba(233, 244, 255, 0.95);
 }
 
 .status-pill--alert {
-  background: rgba(248, 113, 113, 0.24);
-  color: #fecaca;
+  background: rgba(244, 63, 94, 0.22);
+  border-color: rgba(244, 63, 94, 0.3);
+  color: rgba(255, 228, 232, 0.95);
 }
 
 .status-grid {
@@ -380,12 +402,13 @@ input[type='text']:focus {
 .status-card {
   padding: 1.1rem 1.25rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+  backdrop-filter: blur(18px);
 }
 
 .status-card--success {
@@ -413,11 +436,11 @@ input[type='text']:focus {
 .status-card__detail {
   margin: 0.35rem 0 0;
   font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.78);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .muted {
-  color: rgba(226, 232, 240, 0.65);
+  color: var(--polar-muted);
 }
 
 .training-grid {
@@ -435,15 +458,16 @@ input[type='text']:focus {
   gap: 0.9rem;
   padding: 1.35rem;
   border-radius: 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
   transition: transform 0.15s ease, border-color 0.2s ease, background 0.25s ease;
+  backdrop-filter: blur(18px);
 }
 
 .training-card:hover {
   transform: translateY(-2px);
-  border-color: rgba(56, 189, 248, 0.45);
-  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .training-card__meta {
@@ -451,7 +475,7 @@ input[type='text']:focus {
   justify-content: space-between;
   align-items: center;
   font-size: 0.8rem;
-  color: rgba(226, 232, 240, 0.65);
+  color: var(--polar-muted);
 }
 
 .training-card__status {
@@ -463,21 +487,27 @@ input[type='text']:focus {
   letter-spacing: 0.05em;
   text-transform: uppercase;
   font-size: 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .training-card__status--in-progress {
-  background: rgba(56, 189, 248, 0.18);
-  color: #e0f2fe;
+  background: rgba(137, 186, 255, 0.22);
+  border-color: rgba(137, 186, 255, 0.35);
+  color: rgba(233, 244, 255, 0.95);
 }
 
 .training-card__status--assigned {
-  background: rgba(129, 140, 248, 0.2);
-  color: #e9e7ff;
+  background: rgba(245, 158, 11, 0.2);
+  border-color: rgba(251, 191, 36, 0.32);
+  color: rgba(255, 243, 207, 0.95);
 }
 
 .training-card__status--not-started {
-  background: rgba(148, 163, 184, 0.18);
-  color: rgba(226, 232, 240, 0.85);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .training-card__title {
@@ -489,7 +519,7 @@ input[type='text']:focus {
 
 .training-card__description {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(255, 255, 255, 0.8);
   font-size: 0.92rem;
 }
 
@@ -501,10 +531,11 @@ input[type='text']:focus {
 
 .training-card__tag {
   padding: 0.25rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.16);
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.78);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .training-card__progress {
@@ -517,19 +548,19 @@ input[type='text']:focus {
   height: 0.45rem;
   border-radius: 999px;
   overflow: hidden;
-  background: rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .training-card__progress-fill {
   display: block;
   height: 100%;
   border-radius: inherit;
-  background: linear-gradient(135deg, var(--polar-primary), var(--polar-primary-dark));
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .training-card__progress-value {
   font-size: 0.8rem;
-  color: rgba(226, 232, 240, 0.7);
+  color: var(--polar-muted);
 }
 
 .dashboard-list {
@@ -548,13 +579,14 @@ input[type='text']:focus {
   align-items: center;
   padding: 1rem 1.1rem;
   border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   transition: border-color 0.2s ease, transform 0.15s ease;
+  backdrop-filter: blur(16px);
 }
 
 .dashboard-list__item:hover {
-  border-color: rgba(56, 189, 248, 0.4);
+  border-color: rgba(255, 255, 255, 0.3);
   transform: translateY(-1px);
 }
 
@@ -567,22 +599,23 @@ input[type='text']:focus {
 .dashboard-list__description {
   margin: 0.3rem 0 0;
   font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.78);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .dashboard-list__badge {
   display: inline-flex;
   margin-top: 0.6rem;
   padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(56, 189, 248, 0.16);
+  border-radius: 0.65rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   font-size: 0.75rem;
-  color: #e0f2fe;
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .dashboard-list__due {
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.75);
+  color: rgba(255, 255, 255, 0.75);
   white-space: nowrap;
 }
 
@@ -591,7 +624,7 @@ input[type='text']:focus {
 }
 
 .dashboard-list__item--static:hover {
-  border-color: rgba(148, 163, 184, 0.18);
+  border-color: rgba(255, 255, 255, 0.18);
   transform: none;
 }
 
@@ -607,8 +640,9 @@ input[type='text']:focus {
   align-items: center;
   padding: 0.9rem 1.1rem;
   border-radius: 1.1rem;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(14px);
 }
 
 .queue__row--header {
@@ -618,7 +652,7 @@ input[type='text']:focus {
   font-size: 0.72rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.62);
+  color: var(--polar-muted);
 }
 
 .queue__cell {
@@ -629,7 +663,7 @@ input[type='text']:focus {
 
 .queue__cell--center {
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.88);
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .queue__cell--status {
@@ -655,7 +689,7 @@ input[type='text']:focus {
 .training-detail__summary {
   margin: 0;
   font-size: 1rem;
-  color: rgba(226, 232, 240, 0.82);
+  color: rgba(255, 255, 255, 0.82);
 }
 
 .training-detail__meta {
@@ -686,7 +720,7 @@ input[type='text']:focus {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .training-detail__actions {
@@ -782,7 +816,7 @@ input[type='text']:focus {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .employee-dashboard__timestamp {
@@ -831,7 +865,7 @@ input[type='text']:focus {
 .employee-dashboard__metric-value {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .employee-dashboard__card {
@@ -942,7 +976,7 @@ input[type='text']:focus {
   max-width: 28rem;
   display: flex;
   gap: 0.5rem;
-  padding: 0.35rem 0.5rem;
+  padding: 0.5rem 0.75rem;
   border-radius: 1.5rem;
   border: 1px solid rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.05);
@@ -954,7 +988,8 @@ input[type='text']:focus {
   flex: 1;
   display: grid;
   place-items: center;
-  padding: 0.55rem 0;
+  gap: 0.35rem;
+  padding: 0.65rem 0;
   border-radius: 1rem;
   color: rgba(255, 255, 255, 0.8);
   text-decoration: none;
@@ -967,7 +1002,7 @@ input[type='text']:focus {
 
 .employee-dashboard__nav-item--active {
   background: rgba(255, 255, 255, 0.2);
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .employee-dashboard__nav-label {
@@ -1016,7 +1051,7 @@ input[type='text']:focus {
   margin: 0;
   font-size: 1.125rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .training-filter {
@@ -1055,7 +1090,7 @@ input[type='text']:focus {
 
 .training-filter__chip--active {
   background: rgba(255, 255, 255, 0.2);
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .training-library__list {
@@ -1108,7 +1143,7 @@ input[type='text']:focus {
   margin: 0;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .training-library__description {
@@ -1177,7 +1212,7 @@ input[type='text']:focus {
   display: grid;
   place-items: center;
   font-size: 1.25rem;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .employee-profile__identity-text {
@@ -1191,7 +1226,7 @@ input[type='text']:focus {
   margin: 0;
   font-size: 1rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--polar-title);
 }
 
 .employee-profile__subline {


### PR DESCRIPTION
## Summary
- apply the Steel Glacier gradient palette, updated typography, and glass cards throughout the app experience
- refresh chips, tags, progress indicators, and employee dashboard navigation to match the new styling system
- keep the signed-in header controls while removing the old login and signup buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d4aafb2b5c832bb8e8b16b930cf9c7