### PR TITLE
Tighten AeroElevate navigation header layout

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import PolarCard from '@/components/PolarCard';
+import { getBrandName } from '@/lib/brand';
 import { createServerSupabase } from '@/lib/serverSupabase';
 import { getDefaultNextPath, sanitizeNextPath } from '@/lib/sanitizeNextPath';
 import LoginForm from './LoginForm';
@@ -39,9 +40,11 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
     redirect(nextParam || getDefaultNextPath());
   }
 
+  const brand = getBrandName();
+
   return (
     <main className="page">
-      <PolarCard title="Welcome back" subtitle="Access the Polar Ops console">
+      <PolarCard title="Welcome back" subtitle={`Access the ${brand} console`}>
         {statusMessage && <p className={`status-message ${statusVariant}`}>{statusMessage}</p>}
         <LoginForm nextPath={nextParam} />
         <PasswordResetForm />

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import PolarCard from '@/components/PolarCard';
+import { getBrandName } from '@/lib/brand';
 import { createServerSupabase } from '@/lib/serverSupabase';
 import { sanitizeNextPath } from '@/lib/sanitizeNextPath';
 import SignupForm from './SignupForm';
@@ -20,9 +21,11 @@ export default async function SignupPage({ searchParams }: SignupPageProps) {
     redirect(nextParam);
   }
 
+  const brand = getBrandName();
+
   return (
     <main className="page">
-      <PolarCard title="Create your Polar Ops ID" subtitle="Verify your email to access the console">
+      <PolarCard title={`Create your ${brand} ID`} subtitle={`Verify your email to access the ${brand} console`}>
         <SignupForm />
         <p className="helper-text">
           Already verified? <Link href="/login">Sign in</Link> to continue.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,15 +2,18 @@ import type { Metadata } from 'next';
 import { PropsWithChildren } from 'react';
 import '../polar.css';
 import AppNav from '@/components/AppNav';
+import { defaultBrand, getBrandName } from '@/lib/brand';
 import { createServerSupabase } from '@/lib/serverSupabase';
 
 export const metadata: Metadata = {
-  title: process.env.NEXT_PUBLIC_APP_BRAND ? `${process.env.NEXT_PUBLIC_APP_BRAND} | Polar Ops` : 'Polar Ops',
-  description: 'Polar Ops themed authentication starter with Supabase.'
+  title: process.env.NEXT_PUBLIC_APP_BRAND
+    ? `${process.env.NEXT_PUBLIC_APP_BRAND} | ${defaultBrand}`
+    : defaultBrand,
+  description: `${defaultBrand} themed authentication starter with Supabase.`
 };
 
 export default async function RootLayout({ children }: PropsWithChildren) {
-  const brand = process.env.NEXT_PUBLIC_APP_BRAND ?? 'Polar Ops';
+  const brand = getBrandName();
   const supabase = await createServerSupabase();
   const {
     data: { user }

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -1,0 +1,5 @@
+export const defaultBrand = 'AeroElevate';
+
+export function getBrandName(): string {
+  return process.env.NEXT_PUBLIC_APP_BRAND ?? defaultBrand;
+}

--- a/polar.css
+++ b/polar.css
@@ -51,28 +51,39 @@ a {
 
 .app-nav {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  padding: 1.5rem 2rem;
+  gap: 0.4rem;
+  padding: 0.75rem 1rem;
   position: sticky;
   top: 0;
   z-index: 10;
+  width: min(100%, 560px);
+  margin: 0 auto;
   backdrop-filter: blur(20px);
   background: rgba(15, 23, 42, 0.45);
   border-bottom: 1px solid var(--polar-card-border);
+  border-radius: 0 0 var(--polar-radius) var(--polar-radius);
+  text-align: center;
 }
 
 .app-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-weight: 700;
-  font-size: 1.125rem;
-  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
+  line-height: 1.2;
 }
 
 .app-nav__links {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
   align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .app-nav__user {


### PR DESCRIPTION
## Summary
- tighten the navigation header padding and width so the AeroElevate brand stays centered
- shrink the brand wordmark styling for a lighter header presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a3d7dd8c832ba33d10986e61ebbd